### PR TITLE
Support for display of markers or both players (includes DB communication logic)

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,6 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
+    <runningDeviceTargetSelectedWithDropDown>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\Leo\.android\avd\Copy_of_Pixel_2_API_31.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2022-04-01T02:40:38.314545800Z" />
     <targetsSelectedWithDialog>
       <Target>
         <type value="QUICK_BOOT_TARGET" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -21,6 +21,8 @@
         <entry key="..\:/Users/Franck/Desktop/EPFL/BA6/SDP/Displace_hopeful/sdp2022/app/src/main/res/layout/password_update_dialog.xml" value="0.3374094202898551" />
         <entry key="..\:/Users/Franck/Desktop/EPFL/BA6/SDP/Displace_hopeful/sdp2022/app/src/main/res/layout/username_update_dialog.xml" value="0.3392210144927536" />
         <entry key="..\:/Users/Franck/Desktop/EPFL/BA6/SDP/Displace_hopeful/sdp2022/app/src/main/res/layout/username_update_dialog2.xml" value="0.3392210144927536" />
+        <entry key="..\:/Users/Leo/Documents/EPFLBA6/sdp/sdp2022/app/src/main/res/drawable-v24/ic_launcher_foreground.xml" value="0.2075" />
+        <entry key="..\:/Users/Leo/Documents/EPFLBA6/sdp/sdp2022/app/src/main/res/drawable/ic_launcher_background.xml" value="0.16666666666666666" />
         <entry key="..\:/Users/Leo/Documents/EPFLBA6/sdp/sdp2022/app/src/main/res/layout/activity_demo_map.xml" value="0.2" />
         <entry key="..\:/Users/Leo/Documents/EPFLBA6/sdp/sdp2022/app/src/main/res/layout/activity_dummy_login.xml" value="0.10733695652173914" />
         <entry key="..\:/Users/Leo/Documents/EPFLBA6/sdp/sdp2022/app/src/main/res/layout/activity_main.xml" value="0.16666666666666666" />

--- a/app/src/androidTest/java/com/github/displace/sdp2022/map/MarkerManagerTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/map/MarkerManagerTest.kt
@@ -1,0 +1,80 @@
+package com.github.displace.sdp2022.map
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.rule.GrantPermissionRule
+import com.github.displace.sdp2022.DemoMapActivity
+import com.github.displace.sdp2022.DemoMapActivity.Companion.MOCK_MARKERS_POSITIONS
+import com.github.displace.sdp2022.R
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class MarkerManagerTest {
+    @get:Rule
+    val testRule = ActivityScenarioRule(DemoMapActivity::class.java)
+
+    @get:Rule
+    val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        android.Manifest.permission.ACCESS_COARSE_LOCATION,
+        android.Manifest.permission.ACCESS_FINE_LOCATION
+    )
+
+    @Test
+    fun playerPinPointsAreAddedToPlayerRef(){
+        val scenario = testRule.scenario
+        onView(ViewMatchers.withId(R.id.markersToggleButton))
+            .perform(click())
+        onView(ViewMatchers.withId(R.id.map))
+            .perform(longClick())
+            .perform(swipeLeft())
+            .perform(longClick())
+        scenario.onActivity { a ->
+            assertEquals(2,a.markerManager().playerPinPoints().size)
+        }
+
+    }
+
+    @Test
+    fun playerPinPointsAreRemovedFromPlayerRef(){
+        val scenario = testRule.scenario
+        onView(ViewMatchers.withId(R.id.markersToggleButton))
+            .perform(click())
+        onView(ViewMatchers.withId(R.id.map))
+            .perform(longClick())
+            .perform(click())
+        Thread.sleep(MARKER_DESTROY_DELAY)
+        onView(ViewMatchers.withId(R.id.map))
+            .perform(swipeLeft())
+            .perform(longClick())
+        scenario.onActivity { a ->
+            assertEquals(1,a.markerManager().playerPinPoints().size)
+        }
+
+    }
+
+    @Test
+    fun addAllAddsCorrectPositionsToPinpointsRef(){
+        val scenario = testRule.scenario
+
+        onView(ViewMatchers.withId(R.id.toggleMockMarkersButton))
+            .perform(click())
+        scenario.onActivity { a ->
+            val positions = a.mockPinpointsRef.get()
+            assertEquals(MOCK_MARKERS_POSITIONS.size,positions.size)
+            for(i in MOCK_MARKERS_POSITIONS.indices){
+                assertEquals(MOCK_MARKERS_POSITIONS[i].latitude,positions[i].latitude,EPSILON)
+                assertEquals(MOCK_MARKERS_POSITIONS[i].longitude,positions[i].longitude,EPSILON)
+            }
+        }
+
+    }
+
+    companion object{
+        val MARKER_DESTROY_DELAY = 50.toLong()
+        val EPSILON = 1e-4
+    }
+
+}

--- a/app/src/androidTest/java/com/github/displace/sdp2022/map/MarkerManagerTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/map/MarkerManagerTest.kt
@@ -4,6 +4,7 @@ import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.*
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.github.displace.sdp2022.DemoMapActivity
 import com.github.displace.sdp2022.DemoMapActivity.Companion.MOCK_MARKERS_POSITIONS
@@ -11,7 +12,10 @@ import com.github.displace.sdp2022.R
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.osmdroid.util.GeoPoint
 
+@RunWith(AndroidJUnit4::class)
 class MarkerManagerTest {
     @get:Rule
     val testRule = ActivityScenarioRule(DemoMapActivity::class.java)
@@ -62,12 +66,7 @@ class MarkerManagerTest {
         onView(ViewMatchers.withId(R.id.toggleMockMarkersButton))
             .perform(click())
         scenario.onActivity { a ->
-            val positions = a.mockPinpointsRef.get()
-            assertEquals(MOCK_MARKERS_POSITIONS.size,positions.size)
-            for(i in MOCK_MARKERS_POSITIONS.indices){
-                assertEquals(MOCK_MARKERS_POSITIONS[i].latitude,positions[i].latitude,EPSILON)
-                assertEquals(MOCK_MARKERS_POSITIONS[i].longitude,positions[i].longitude,EPSILON)
-            }
+            assertCorrectPositions(MOCK_MARKERS_POSITIONS,a.mockPinpointsRef.get())
         }
 
     }
@@ -75,6 +74,14 @@ class MarkerManagerTest {
     companion object{
         val MARKER_DESTROY_DELAY = 50.toLong()
         val EPSILON = 1e-4
+
+        fun assertCorrectPositions(expected: List<GeoPoint>,actual: List<GeoPoint>){
+            assertEquals(expected.size,actual.size)
+            for(i in expected.indices){
+                assertEquals(expected[i].latitude,actual[i].latitude,EPSILON)
+                assertEquals(expected[i].longitude,actual[i].longitude,EPSILON)
+            }
+        }
     }
 
 }

--- a/app/src/androidTest/java/com/github/displace/sdp2022/map/PinpointsDBCommunicationHandlerTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/map/PinpointsDBCommunicationHandlerTest.kt
@@ -1,0 +1,58 @@
+package com.github.displace.sdp2022.map
+
+import android.app.TaskStackBuilder
+import android.provider.ContactsContract
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import com.github.displace.sdp2022.Database
+import com.github.displace.sdp2022.DemoMapActivity
+import com.github.displace.sdp2022.DemoMapActivity.Companion.MOCK_MARKERS_POSITIONS
+import com.github.displace.sdp2022.R
+import com.github.displace.sdp2022.RealTimeDatabase
+import com.github.displace.sdp2022.map.MarkerManagerTest.Companion.assertCorrectPositions
+import com.google.android.gms.tasks.Task
+import com.google.firebase.database.DataSnapshot
+import com.google.firebase.database.DatabaseReference
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.lang.UnsupportedOperationException
+
+@RunWith(AndroidJUnit4::class)
+class PinpointsDBCommunicationHandlerTest {
+    @get:Rule
+    val testRule = ActivityScenarioRule(DemoMapActivity::class.java)
+
+    @get:Rule
+    val permissionRule = GrantPermissionRule.grant(
+        android.Manifest.permission.ACCESS_COARSE_LOCATION,
+        android.Manifest.permission.ACCESS_FINE_LOCATION
+    )
+
+    @Test
+    fun communicationIsSuccessful(){
+        val scenario = testRule.scenario
+        onView(ViewMatchers.withId(R.id.DBButton)).perform(click())
+        Thread.sleep(DB_DELAY)
+        onView(ViewMatchers.withId(R.id.toggleMockMarkersButton)).perform(click())
+        Thread.sleep(DB_DELAY)
+        onView(ViewMatchers.withId(R.id.updateButton)).perform(click())
+        Thread.sleep(DB_DELAY)
+        scenario.onActivity { a ->
+            assertCorrectPositions(MOCK_MARKERS_POSITIONS, a.mockPinpointsRef.get())
+            assertCorrectPositions(MOCK_MARKERS_POSITIONS, a.remoteMockPinpointsRef.get())
+        }
+    }
+
+    companion object {
+        val DB_DELAY = 2000.toLong()
+    }
+
+
+
+}

--- a/app/src/main/java/com/github/displace/sdp2022/DemoMapActivity.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/DemoMapActivity.kt
@@ -5,9 +5,11 @@ import android.view.View
 import android.widget.Toast
 import android.widget.ToggleButton
 import androidx.appcompat.app.AppCompatActivity
+import com.github.displace.sdp2022.gameComponents.Player
 import com.github.displace.sdp2022.map.MapViewManager
 import com.github.displace.sdp2022.map.MapViewManager.Companion.DEFAULT_CENTER
 import com.github.displace.sdp2022.map.MarkerManager
+import com.github.displace.sdp2022.map.PinpointsDBCommunicationHandler
 import com.github.displace.sdp2022.util.PreferencesUtil
 import com.github.displace.sdp2022.util.gps.GPSPositionManager
 import com.github.displace.sdp2022.util.gps.GPSPositionUpdater
@@ -26,6 +28,9 @@ class DemoMapActivity : AppCompatActivity() {
     private lateinit var posToastListener: GeoPointListener
     private lateinit var markerManager: MarkerManager
     lateinit var mockPinpointsRef: MarkerManager.PinpointsRef
+    lateinit var remoteMockPinpointsRef: MarkerManager.PinpointsRef
+    private lateinit var dbHandler: PinpointsDBCommunicationHandler
+    private var useDB = false
 
     /**
      * @param savedInstanceState
@@ -46,6 +51,9 @@ class DemoMapActivity : AppCompatActivity() {
         gpsPositionUpdater.listenersManager.addCall(markerListener)
 
         mockPinpointsRef = markerManager.PinpointsRef()
+        remoteMockPinpointsRef = markerManager.PinpointsRef()
+        val db = RealTimeDatabase().noCacheInstantiate("https://displace-dd51e-default-rtdb.europe-west1.firebasedatabase.app/",false)
+        dbHandler = PinpointsDBCommunicationHandler(db,MOCK_GAME_INSTANCE_NAME)
     }
 
     override fun onBackPressed() {
@@ -119,10 +127,27 @@ class DemoMapActivity : AppCompatActivity() {
         } else {
             removeMockMarkers()
         }
+        if(useDB){
+            dbHandler.updateDBPinpoints(MOCK_PLAYER,mockPinpointsRef)
+        }
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun updateRemoteMockPinPoints(view: View){
+        if(useDB){
+            dbHandler.updateLocalPinpoints(MOCK_PLAYER,remoteMockPinpointsRef)
+        }
+    }
+
+    fun toggleDB(view : View){
+        val toggleButton = view as ToggleButton
+        useDB = toggleButton.isChecked
     }
 
     companion object {
         val MOCK_MARKERS_POSITIONS = listOf(DEFAULT_CENTER, GeoPoint(6.5,-4.0), GeoPoint(6.7,47.0))
+        const val MOCK_GAME_INSTANCE_NAME = "demoMapMock"
+        val MOCK_PLAYER = Player(0.0,0.0,0)
     }
 
 

--- a/app/src/main/java/com/github/displace/sdp2022/DemoMapActivity.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/DemoMapActivity.kt
@@ -6,13 +6,14 @@ import android.widget.Toast
 import android.widget.ToggleButton
 import androidx.appcompat.app.AppCompatActivity
 import com.github.displace.sdp2022.map.MapViewManager
+import com.github.displace.sdp2022.map.MapViewManager.Companion.DEFAULT_CENTER
+import com.github.displace.sdp2022.map.MarkerManager
 import com.github.displace.sdp2022.util.PreferencesUtil
 import com.github.displace.sdp2022.util.gps.GPSPositionManager
 import com.github.displace.sdp2022.util.gps.GPSPositionUpdater
 import com.github.displace.sdp2022.util.gps.GeoPointListener
 import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
-import kotlin.concurrent.timer
 
 
 class DemoMapActivity : AppCompatActivity() {
@@ -23,6 +24,8 @@ class DemoMapActivity : AppCompatActivity() {
     private lateinit var gpsPositionManager: GPSPositionManager
     private lateinit var markerListener: GeoPointListener
     private lateinit var posToastListener: GeoPointListener
+    private lateinit var markerManager: MarkerManager
+    lateinit var mockPinpointsRef: MarkerManager.PinpointsRef
 
     /**
      * @param savedInstanceState
@@ -35,11 +38,14 @@ class DemoMapActivity : AppCompatActivity() {
         setContentView(R.layout.activity_demo_map)
         mapView = findViewById<MapView>(R.id.map)
         mapViewManager = MapViewManager(mapView)
-        markerListener = GeoPointListener.markerPlacer(mapView)
+        markerManager = MarkerManager(mapView)
+        markerListener = GeoPointListener {p -> markerManager.putMarker(p)}
         posToastListener = GeoPointListener { geoPoint -> Toast.makeText(this,String.format("( %.4f ; %.4f )",geoPoint.latitude,geoPoint.longitude),Toast.LENGTH_SHORT).show() }
         gpsPositionManager = GPSPositionManager(this)
         gpsPositionUpdater = GPSPositionUpdater(this,gpsPositionManager)
         gpsPositionUpdater.listenersManager.addCall(markerListener)
+
+        mockPinpointsRef = markerManager.PinpointsRef()
     }
 
     override fun onBackPressed() {
@@ -92,6 +98,31 @@ class DemoMapActivity : AppCompatActivity() {
 
     fun mapViewListeners() : List<GeoPointListener>{
         return mapViewManager.currentOnLongClickListeners()
+    }
+
+    fun markerManager(): MarkerManager{
+        return markerManager
+    }
+
+    private fun displayMockMarkers(){
+        mockPinpointsRef.set(MOCK_MARKERS_POSITIONS)
+    }
+
+    private fun removeMockMarkers(){
+        mockPinpointsRef.clear()
+    }
+
+    fun toggleMockMarkers(view : View){
+        val toggleButton = view as ToggleButton
+        if(toggleButton.isChecked){
+            displayMockMarkers()
+        } else {
+            removeMockMarkers()
+        }
+    }
+
+    companion object {
+        val MOCK_MARKERS_POSITIONS = listOf(DEFAULT_CENTER, GeoPoint(6.5,-4.0), GeoPoint(6.7,47.0))
     }
 
 

--- a/app/src/main/java/com/github/displace/sdp2022/map/MarkerManager.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/map/MarkerManager.kt
@@ -4,18 +4,110 @@ import org.osmdroid.util.GeoPoint
 import org.osmdroid.views.MapView
 import org.osmdroid.views.overlay.Marker
 
+/**
+ * Handling (creating,removing) Markers (ie, pinpoints) on a map (mapView) should always
+ * be done through this class, which provides several methods
+ * and abstracts over OSMdroid's API
+ * @param mapView on which we put the markers
+ * @author LeoLgdr
+ */
 class MarkerManager(private val mapView: MapView) {
+    private var pinPointsMap = mutableMapOf<PinpointsRef,List<Marker>>()
+    private val playerPinPointsRef = PinpointsRef()
 
+    /**
+     * adds a marker to a position. the marker is removable by click
+     * this method is intended to be used for the player's guesses of the other player's position
+     *
+     * for putting the opponent's guesses, use addPinPoints
+     * @param pos coordinates of the Marker
+     */
     fun putMarker(pos: GeoPoint) {
+        playerPinPointsRef.add(pos,true)
+        mapView.invalidate()
+    }
+
+    private fun newMarker(pos: GeoPoint, isRemovedOnClick: Boolean, pinpointsRef: PinpointsRef): Marker{
         val marker = Marker(mapView)
-        marker.position = pos
+        marker.position = pos.clone()
         marker.setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_CENTER)
         mapView.overlayManager.add(marker)
-        marker.setOnMarkerClickListener { mkr, mapV ->
-            mapV.overlayManager.remove(mkr)
-            mapV.invalidate()
+        if(isRemovedOnClick){
+            removeOnClick(marker, pinpointsRef)
+        } else {
+            marker.setOnMarkerClickListener {_,_ -> false}
+        }
+        return marker
+    }
+
+    private fun removeOnClick(marker: Marker, pinpointsRef: PinpointsRef){
+        marker.setOnMarkerClickListener { _, _ ->
+            pinpointsRef.remove(marker)
             false
         }
-        mapView.invalidate()
+    }
+
+    /**
+     * @return the Player's current pinpoints of the opponent's location
+     */
+    fun playerPinPoints(): List<GeoPoint>{
+        return playerPinPointsRef.get()
+    }
+
+    /**
+     * for ease of Marker handling
+     */
+    inner class PinpointsRef {
+        /**
+         * changes the set of associated markers to a new one.
+         * the old markers are removed from the map,
+         * new ones are put, corresponding to the new positions
+         *
+         * The new markers are NOT removed on click
+         * @param newPositions
+         */
+        fun set(newPositions: List<GeoPoint>){
+            clear()
+            pinPointsMap[this] = newPositions.map{ p -> newMarker(p,false,this)}
+            mapView.invalidate()
+        }
+
+        /**
+         * adds a Marker
+         * @param position of the marker
+         * @param isRemovedOnClick true iff the player can remove the marker by click
+         */
+        fun add(position: GeoPoint,isRemovedOnClick: Boolean){
+            val pinPoints = pinPointsMap[this]?.toMutableList() ?: mutableListOf()
+            pinPoints.add(newMarker(position,isRemovedOnClick,this))
+            pinPointsMap[this] = pinPoints.toList()
+            mapView.invalidate()
+        }
+
+        /**
+         * @return markers positions
+         */
+        fun get(): List<GeoPoint> {
+            return pinPointsMap[this]?.map{ m -> m.position.clone()} ?:  listOf()
+        }
+
+        /**
+         * remove all associated markers from the map
+         */
+        fun clear(){
+            pinPointsMap[this]?.map { m -> mapView.overlayManager.remove(m) }
+            mapView.invalidate()
+        }
+
+        /**
+         * remove the specified marker
+         */
+        fun remove(marker: Marker){
+            if(pinPointsMap[this]?.contains(marker) == true){
+                pinPointsMap[this] = pinPointsMap[this]!!.filter { m -> m != marker }
+                mapView.overlayManager.remove(marker)
+                mapView.invalidate()
+            }
+        }
     }
 }

--- a/app/src/main/java/com/github/displace/sdp2022/map/PinpointsDBCommunicationHandler.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/map/PinpointsDBCommunicationHandler.kt
@@ -1,0 +1,37 @@
+package com.github.displace.sdp2022.map
+
+import android.util.Log
+import com.github.displace.sdp2022.Database
+import com.github.displace.sdp2022.gameComponents.Player
+import org.osmdroid.util.GeoPoint
+
+/**
+ * to send and retrieve position guesses of players
+ * @param db database to send/retrieve the pinpoints from
+ * @author LeoLgdr
+ */
+class PinpointsDBCommunicationHandler(private val db: Database, private val gameInstanceName: String) {
+
+    /**
+     * to send the player's pinpoints
+     * @param player local player
+     * @param pinpointsRef local reference to the pinpoints
+     */
+    fun updateDBPinpoints(player: Player, pinpointsRef: MarkerManager.PinpointsRef){
+        val positions = pinpointsRef.get()
+        db.update("GameInstance/${gameInstanceName}/id:" + player.uid,"pinpoints",positions.map { p -> listOf(p.latitude,p.longitude) })
+    }
+
+    /**
+     * to retrieve the opponent's pinpoints (ASYNCHRONOUS UPDATE OF LOCAL REF)
+     * @param player opponent (ie, the remote user in game with the local player)
+     * @param pinpointsRef local reference to the pinpoints
+     */
+    fun updateLocalPinpoints(player: Player, pinpointsRef: MarkerManager.PinpointsRef){
+        db.referenceGet("GameInstance/${gameInstanceName}/id:" + player.uid,"pinpoints").addOnSuccessListener { r ->
+            pinpointsRef.set( (r.value as List<List<Double>>).map{x ->
+                GeoPoint(x[0],x[1])
+            } )
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_demo_map.xml
+++ b/app/src/main/res/layout/activity_demo_map.xml
@@ -44,14 +44,39 @@
             android:onClick="disableAllListeners"
             android:text="disable all" />
 
-        <ToggleButton
-            android:id="@+id/toggleMockMarkersButton"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:onClick="toggleMockMarkers"
-            android:text="mock markers"
-            android:textOff="mock markers"
-            android:textOn="mock markers" />
+            android:orientation="horizontal">
+
+                <ToggleButton
+                    android:id="@+id/DBButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:onClick="toggleDB"
+                    android:text="ToggleButton"
+                    android:textOff="DB"
+                    android:textOn="DB" />
+
+                <Button
+                    android:id="@+id/updateButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:onClick="updateRemoteMockPinPoints"
+                    android:text="update" />
+
+                <ToggleButton
+                    android:id="@+id/toggleMockMarkersButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:onClick="toggleMockMarkers"
+                    android:text="mock markers"
+                    android:textOff="mock markers"
+                    android:textOn="mock markers" />
+
+        </LinearLayout>
 
         <org.osmdroid.views.MapView
             android:id="@+id/map"

--- a/app/src/main/res/layout/activity_demo_map.xml
+++ b/app/src/main/res/layout/activity_demo_map.xml
@@ -44,6 +44,15 @@
             android:onClick="disableAllListeners"
             android:text="disable all" />
 
+        <ToggleButton
+            android:id="@+id/toggleMockMarkersButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:onClick="toggleMockMarkers"
+            android:text="mock markers"
+            android:textOff="mock markers"
+            android:textOn="mock markers" />
+
         <org.osmdroid.views.MapView
             android:id="@+id/map"
             android:layout_width="match_parent"


### PR DESCRIPTION
the ultimate goal is to use this to display all of the pinpoint guesses of the players on the map (will put in this same PR later)

EDIT: added the DB communications logic for the pinpoints (PinpointsDBCommunicationHandler)