### PR TITLE
fixed PinpointsRef::clear bug

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -7,23 +7,11 @@
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\fesqv\.android\avd\Pixel_4_API_31.avd" />
+            <value value="C:\Users\Leo\.android\avd\Copy_of_Pixel_2_API_31.avd" />
           </Key>
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2022-04-02T19:45:50.830507600Z" />
-    <multipleDevicesSelectedInDropDown value="true" />
-    <targetsSelectedWithDialog>
-      <Target>
-        <type value="QUICK_BOOT_TARGET" />
-        <deviceKey>
-          <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\fesqv\.android\avd\Pixel_4_API_31.avd" />
-          </Key>
-        </deviceKey>
-      </Target>
-    </targetsSelectedWithDialog>
+    <timeTargetWasSelectedWithDropDown value="2022-04-06T11:41:40.341911700Z" />
   </component>
 </project>

--- a/app/src/androidTest/java/com/github/displace/sdp2022/map/MarkerManagerTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/map/MarkerManagerTest.kt
@@ -71,6 +71,19 @@ class MarkerManagerTest {
 
     }
 
+    @Test
+    fun clearRemovesAllPinpointsFromPinpointsRef(){
+        val scenario = testRule.scenario
+        onView(ViewMatchers.withId(R.id.toggleMockMarkersButton))
+            .perform(click())
+        onView(ViewMatchers.withId(R.id.toggleMockMarkersButton))
+            .perform(click())
+        Thread.sleep(MARKER_DESTROY_DELAY)
+        scenario.onActivity { a ->
+            assertCorrectPositions(listOf(),a.mockPinpointsRef.get())
+        }
+    }
+
     companion object{
         val MARKER_DESTROY_DELAY = 50.toLong()
         val EPSILON = 1e-4

--- a/app/src/androidTest/java/com/github/displace/sdp2022/map/PinpointsDBCommunicationHandlerTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/map/PinpointsDBCommunicationHandlerTest.kt
@@ -35,7 +35,7 @@ class PinpointsDBCommunicationHandlerTest {
     )
 
     @Test
-    fun communicationIsSuccessful(){
+    fun communicationIsSuccessfulOnNonEmptyPinpoints(){
         val scenario = testRule.scenario
         onView(ViewMatchers.withId(R.id.DBButton)).perform(click())
         Thread.sleep(DB_DELAY)
@@ -46,6 +46,25 @@ class PinpointsDBCommunicationHandlerTest {
         scenario.onActivity { a ->
             assertCorrectPositions(MOCK_MARKERS_POSITIONS, a.mockPinpointsRef.get())
             assertCorrectPositions(MOCK_MARKERS_POSITIONS, a.remoteMockPinpointsRef.get())
+        }
+    }
+
+    @Test
+    fun communicationIsSuccessfulOnEmptyPinpoints(){
+        val scenario = testRule.scenario
+        onView(ViewMatchers.withId(R.id.DBButton)).perform(click())
+        Thread.sleep(DB_DELAY)
+        onView(ViewMatchers.withId(R.id.toggleMockMarkersButton)).perform(click())
+        Thread.sleep(DB_DELAY)
+        onView(ViewMatchers.withId(R.id.updateButton)).perform(click())
+        Thread.sleep(DB_DELAY)
+        onView(ViewMatchers.withId(R.id.toggleMockMarkersButton)).perform(click())
+        Thread.sleep(DB_DELAY)
+        onView(ViewMatchers.withId(R.id.updateButton)).perform(click())
+        Thread.sleep(DB_DELAY)
+        scenario.onActivity { a ->
+            assertCorrectPositions(listOf(), a.mockPinpointsRef.get())
+            assertCorrectPositions(listOf(), a.remoteMockPinpointsRef.get())
         }
     }
 

--- a/app/src/main/java/com/github/displace/sdp2022/map/MarkerManager.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/map/MarkerManager.kt
@@ -96,6 +96,7 @@ class MarkerManager(private val mapView: MapView) {
          */
         fun clear(){
             pinPointsMap[this]?.map { m -> mapView.overlayManager.remove(m) }
+            pinPointsMap[this] = listOf()
             mapView.invalidate()
         }
 

--- a/app/src/main/java/com/github/displace/sdp2022/map/PinpointsDBCommunicationHandler.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/map/PinpointsDBCommunicationHandler.kt
@@ -19,7 +19,7 @@ class PinpointsDBCommunicationHandler(private val db: Database, private val game
      */
     fun updateDBPinpoints(player: Player, pinpointsRef: MarkerManager.PinpointsRef){
         val positions = pinpointsRef.get()
-        db.update("GameInstance/${gameInstanceName}/id:" + player.uid,"pinpoints",positions.map { p -> listOf(p.latitude,p.longitude) })
+        db.update("GameInstance/${gameInstanceName}/id:${player.uid}","pinpoints",positions.map { p -> listOf(p.latitude,p.longitude) })
     }
 
     /**
@@ -28,9 +28,9 @@ class PinpointsDBCommunicationHandler(private val db: Database, private val game
      * @param pinpointsRef local reference to the pinpoints
      */
     fun updateLocalPinpoints(player: Player, pinpointsRef: MarkerManager.PinpointsRef){
-        db.referenceGet("GameInstance/${gameInstanceName}/id:" + player.uid,"pinpoints").addOnSuccessListener { r ->
-            pinpointsRef.set( (r.value as List<List<Double>>).map{x ->
-                GeoPoint(x[0],x[1])
+        db.referenceGet("GameInstance/${gameInstanceName}/id:${player.uid}","pinpoints").addOnSuccessListener { r ->
+            pinpointsRef.set( ( (r.value ?: listOf<List<Double>>()) as List<List<Double>>).map{ l ->
+                GeoPoint(l[0],l[1])
             } )
         }
     }


### PR DESCRIPTION
calling clear used to only remove markers from the map, while not removing the markers from the ref itself. A few tests were added to highlight it (bug was only apparent when testing PinpointsRef after a clear), and then the bug was fixed. A few minor changes were done to PinpointsDBCommunicationHandler, to handle null values in DB and use format strings in the url instead of string concatenation