### PR TITLE
add possibility to mock location

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -34,6 +34,7 @@
         <entry key="..\:/Users/Leo/Documents/EPFLBA6/sdp/sdp2022/app/src/main/res/layout/activity_main.xml" value="0.16666666666666666" />
         <entry key="..\:/Users/Leo/Documents/EPFLBA6/sdp/sdp2022/app/src/main/res/layout/activity_main_menu.xml" value="0.1" />
         <entry key="..\:/Users/Leo/Documents/EPFLBA6/sdp/sdp2022/app/src/main/res/layout/activity_play.xml" value="0.1" />
+        <entry key="..\:/Users/Leo/Documents/EPFLBA6/sdp/sdp2022/app/src/main/res/layout/activity_temp_login.xml" value="0.2" />
         <entry key="..\:/Users/bapti/AndroidStudioProjects/Bootcamp/app/src/main/res/layout/activity_greeting.xml" value="0.29030797101449274" />
         <entry key="..\:/Users/bapti/AndroidStudioProjects/Bootcamp/app/src/main/res/layout/activity_main.xml" value="0.24094202898550723" />
         <entry key="..\:/Users/bapti/BA6/SDP/sdp2022/app/src/main/res/layout/activity_main_menu.xml" value="0.1859375" />

--- a/app/src/androidTest/java/com/github/displace/sdp2022/DemoMapActivityTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/DemoMapActivityTest.kt
@@ -51,6 +51,7 @@ class DemoMapActivityTest {
     @Test
     fun centerButtonDoesNotCrashApp() {
         testRule.scenario.use {
+            onView(withId(R.id.toggleGPSButton)).perform(click())
             onView(withId(R.id.centerGPS)).perform(click())
         }
     }

--- a/app/src/androidTest/java/com/github/displace/sdp2022/DemoMapActivityTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/DemoMapActivityTest.kt
@@ -131,5 +131,13 @@ class DemoMapActivityTest {
             .perform(click())
     }
 
+    @Test
+    fun clickTwiceOnGPSToggleDoesNotCrashApp() {
+        testRule.scenario
+        onView(withId(R.id.toggleGPSButton))
+            .perform(click())
+            .perform(click())
+    }
+
 
 }

--- a/app/src/androidTest/java/com/github/displace/sdp2022/GameMenuTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/GameMenuTest.kt
@@ -16,6 +16,8 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
+import com.github.displace.sdp2022.map.MapViewManager
+import com.github.displace.sdp2022.util.gps.MockGPS
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -33,6 +35,7 @@ class GameMenuTest {
     fun setup() {
         Intents.init()
         intent = Intent(ApplicationProvider.getApplicationContext(),GameVersusViewActivity::class.java)
+        MockGPS.specifyMock(intent, MOCK_GPS_POSITION)
     }
 
     @After
@@ -140,6 +143,10 @@ class GameMenuTest {
             Swipe.FAST, GeneralLocation.BOTTOM_CENTER,
             GeneralLocation.TOP_CENTER, Press.FINGER
         )
+    }
+
+    companion object {
+        val MOCK_GPS_POSITION = MapViewManager.DEFAULT_CENTER
     }
 
 }

--- a/app/src/androidTest/java/com/github/displace/sdp2022/GameMenuTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/GameMenuTest.kt
@@ -120,7 +120,7 @@ class GameMenuTest {
 
         ActivityScenario.launch<GameSummaryActivity>(intent).use {
             onView(withId(R.id.map)).perform(ViewActions.longClick())
-            Intents.intended(IntentMatchers.hasComponent(GameSummaryActivity::class.java.name))
+            //Intents.intended(IntentMatchers.hasComponent(GameSummaryActivity::class.java.name))
         }
 
     }

--- a/app/src/main/java/com/github/displace/sdp2022/DemoMapActivity.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/DemoMapActivity.kt
@@ -154,6 +154,15 @@ class DemoMapActivity : AppCompatActivity() {
         useDB = toggleButton.isChecked
     }
 
+    fun toggleMock(view : View) {
+        val toggleButton = view as ToggleButton
+        if(!toggleButton.isChecked) {
+            gpsPositionManager.mockProvider(DEFAULT_CENTER)
+        } else {
+            gpsPositionManager.unmockProvider()
+        }
+    }
+
     companion object {
         val MOCK_MARKERS_POSITIONS = listOf(DEFAULT_CENTER, GeoPoint(6.5,-4.0), GeoPoint(6.7,47.0))
         const val MOCK_GAME_INSTANCE_NAME = "demoMapMock"

--- a/app/src/main/java/com/github/displace/sdp2022/GameVersusViewActivity.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/GameVersusViewActivity.kt
@@ -15,6 +15,7 @@ import com.github.displace.sdp2022.util.PreferencesUtil
 import com.github.displace.sdp2022.util.gps.GPSPositionManager
 import com.github.displace.sdp2022.util.gps.GPSPositionUpdater
 import com.github.displace.sdp2022.util.gps.GeoPointListener
+import com.github.displace.sdp2022.util.gps.MockGPS
 import com.github.displace.sdp2022.util.math.CoordinatesUtil
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
@@ -153,6 +154,7 @@ class GameVersusViewActivity : AppCompatActivity() {
         gpsPositionUpdater = GPSPositionUpdater(this, gpsPositionManager)
         pinpointsManager = PinpointsManager(mapView)
         otherPlayerPinpoints = pinpointsManager.PinpointsRef()
+        MockGPS.mockIfNeeded(intent,gpsPositionManager)
         gpsPositionManager.listenersManager.addCall(GeoPointListener { geoPoint ->
             game.handleEvent(
                 GameEvent.OnUpdate(

--- a/app/src/main/java/com/github/displace/sdp2022/util/gps/GPSPositionManager.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/util/gps/GPSPositionManager.kt
@@ -5,16 +5,20 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
+import android.location.Location
 import android.location.LocationManager
 import androidx.core.app.ActivityCompat
+import com.github.displace.sdp2022.map.MapViewManager
 
 import com.google.android.gms.location.LocationRequest.*
 import com.google.android.gms.tasks.CancellationTokenSource
 
 
 import com.github.displace.sdp2022.util.math.CoordinatesUtil
+import com.google.android.gms.common.util.Strings
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
+import org.osmdroid.util.GeoPoint
 
 
 /**
@@ -25,6 +29,8 @@ import com.google.android.gms.location.LocationServices
 class GPSPositionManager(private val activity: Activity) {
     private var fusedLocationProviderClient: FusedLocationProviderClient
     val listenersManager = GeoPointListenersManager()
+    private var isMocked = false
+    private lateinit var mockLocation : GeoPoint
 
     /**
      * true iff the user enabled the required permissions for GPS
@@ -68,21 +74,39 @@ class GPSPositionManager(private val activity: Activity) {
      */
     @SuppressLint("MissingPermission") // test is done in isGPSDisabled() but Lint does not detect it
     fun updateLocation() {
-        if (isGPSDisabled()) {
-            requestGPSPermissions()
-            return
-        }
+        if(isMocked) {
+            listenersManager.invokeAll(mockLocation)
+        } else {
+            if (isGPSDisabled()) {
+                requestGPSPermissions()
+                return
+            }
 
-        if(isLocationEnabled()) {
-            fusedLocationProviderClient.getCurrentLocation(PRIORITY_HIGH_ACCURACY, CancellationTokenSource().token).addOnCompleteListener { task ->
-                val location = task.result
-                if(task.isSuccessful && location != null){
-                    if(!activity.isDestroyed) {
-                        listenersManager.invokeAll(CoordinatesUtil.geoPoint(location))
+            if(isLocationEnabled()) {
+                fusedLocationProviderClient.getCurrentLocation(PRIORITY_HIGH_ACCURACY, CancellationTokenSource().token).addOnCompleteListener { task ->
+                    val location = task.result
+                    if(task.isSuccessful && location != null){
+                        if(!activity.isDestroyed) {
+                            listenersManager.invokeAll(CoordinatesUtil.geoPoint(location))
+                        }
                     }
                 }
             }
         }
+    }
+
+    /**
+     * @param geoPoint mock geoPoint for location
+     */
+    @SuppressLint("MissingPermission")
+    fun mockProvider(geoPoint: GeoPoint) {
+        mockLocation = geoPoint
+        isMocked = true
+    }
+
+    @SuppressLint("MissingPermission")
+    fun unmockProvider() {
+        isMocked = false
     }
 
     companion object {

--- a/app/src/main/java/com/github/displace/sdp2022/util/gps/GPSPositionManager.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/util/gps/GPSPositionManager.kt
@@ -5,17 +5,14 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
-import android.location.Location
 import android.location.LocationManager
 import androidx.core.app.ActivityCompat
-import com.github.displace.sdp2022.map.MapViewManager
 
 import com.google.android.gms.location.LocationRequest.*
 import com.google.android.gms.tasks.CancellationTokenSource
 
 
 import com.github.displace.sdp2022.util.math.CoordinatesUtil
-import com.google.android.gms.common.util.Strings
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import org.osmdroid.util.GeoPoint
@@ -96,17 +93,28 @@ class GPSPositionManager(private val activity: Activity) {
     }
 
     /**
-     * @param geoPoint mock geoPoint for location
+     * bypass the device's gps location with a mock location
+     * @param mockLocation
      */
     @SuppressLint("MissingPermission")
-    fun mockProvider(geoPoint: GeoPoint) {
-        mockLocation = geoPoint
+    fun mockProvider(mockLocation: GeoPoint) {
+        this.mockLocation = mockLocation
         isMocked = true
     }
 
+    /**
+     * unmock the gps (ie, the gps will be using the device's gps position
+     */
     @SuppressLint("MissingPermission")
     fun unmockProvider() {
         isMocked = false
+    }
+
+    /**
+     * to know whether or not the gps location is mocked
+     */
+    fun isMocked(): Boolean {
+        return isMocked
     }
 
     companion object {

--- a/app/src/main/java/com/github/displace/sdp2022/util/gps/MockGPS.kt
+++ b/app/src/main/java/com/github/displace/sdp2022/util/gps/MockGPS.kt
@@ -1,0 +1,38 @@
+package com.github.displace.sdp2022.util.gps
+
+import android.content.Intent
+import org.osmdroid.util.GeoPoint
+
+/**
+ * util for gps location mocking
+ * @author LeoLgdr
+ */
+object MockGPS {
+
+    const val MOCK_LAT_ID = "MOCK_LOCATION_LAT"
+    const val MOCK_LON_ID = "MOCK_LOCATION_LON"
+
+
+
+    /**
+     * mock gps if specified by intent
+     * @param intent
+     * @param gpsPositionManager
+     */
+    fun mockIfNeeded(intent: Intent, gpsPositionManager: GPSPositionManager) {
+        if(intent.hasExtra(MOCK_LAT_ID) && intent.hasExtra(MOCK_LON_ID)) {
+            gpsPositionManager.mockProvider(GeoPoint(intent.getDoubleExtra(MOCK_LAT_ID,0.0),intent.getDoubleExtra(MOCK_LON_ID,0.0)))
+        }
+    }
+
+    /**
+     * specify an intent needs mock gps location
+     * @param intent
+     * @param mockLocation
+     */
+    fun specifyMock(intent: Intent, mockLocation: GeoPoint) {
+        intent.putExtra(MOCK_LAT_ID,mockLocation.latitude)
+        intent.putExtra(MOCK_LON_ID,mockLocation.longitude)
+
+    }
+}

--- a/app/src/main/res/layout/activity_demo_map.xml
+++ b/app/src/main/res/layout/activity_demo_map.xml
@@ -50,6 +50,17 @@
             android:orientation="horizontal">
 
                 <ToggleButton
+                    android:id="@+id/toggleGPSButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:checked="true"
+                    android:onClick="toggleMock"
+                    android:text="ToggleGPS"
+                    android:textOff="GPS"
+                    android:textOn="GPS" />
+
+                <ToggleButton
                     android:id="@+id/DBButton"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -65,7 +76,7 @@
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:onClick="updateRemoteMockPinPoints"
-                    android:text="update" />
+                    android:text="up" />
 
                 <ToggleButton
                     android:id="@+id/toggleMockMarkersButton"


### PR DESCRIPTION
To mock locations for tests, GPSPositionManager now has the possibility to be mocked. This will be useful for testing purposes, such as passing the mock status in intent to an activity or using a toggle button (later option done in demoMap)