### PR TITLE
fix tests involving guest mode

### DIFF
--- a/app/src/androidTest/java/com/github/displace/sdp2022/accountSettings/AccountSettingsActivityPermsTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/accountSettings/AccountSettingsActivityPermsTest.kt
@@ -61,6 +61,7 @@ class AccountSettingsActivityPermsTest {
     fun logout() {
         pressBack()
         pressBack()
+        (ApplicationProvider.getApplicationContext() as MyApplication).getActiveUser()?.removeUserFromDatabase()
     }
 
     /*@Test

--- a/app/src/androidTest/java/com/github/displace/sdp2022/news/NewsActivityTest.kt
+++ b/app/src/androidTest/java/com/github/displace/sdp2022/news/NewsActivityTest.kt
@@ -1,5 +1,6 @@
 package com.github.displace.sdp2022.news
 
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.assertion.ViewAssertions
@@ -7,8 +8,10 @@ import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.displace.sdp2022.MainActivity
+import com.github.displace.sdp2022.MyApplication
 import com.github.displace.sdp2022.R
 import com.github.displace.sdp2022.map.PinpointsDBHandlerTest.Companion.DB_DELAY
+import org.junit.After
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,6 +21,11 @@ class NewsActivityTest {
 
     @get:Rule
     val testRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @After
+    fun removeAnonymousUserFromDB() {
+        (ApplicationProvider.getApplicationContext() as MyApplication).getActiveUser()?.removeUserFromDatabase()
+    }
 
     @Test
     fun startToNewsTest() {


### PR DESCRIPTION
adds anonymous user deletion after the tests that involve login in as guest, in order to avoid filling the database with anonymous users each time these tests are run